### PR TITLE
Refactored VCardFormatError into subclasses

### DIFF
--- a/vcard/test/test_package.py
+++ b/vcard/test/test_package.py
@@ -210,7 +210,7 @@ class TestVCards(unittest.TestCase):
                     with warnings.catch_warnings(record=True):
                         vcard.VCard(vcard_text, filename=vcard_file)
                         self.fail('Invalid vCard created:\n{0}'.format(vcard_text))
-                except vcard_errors.VCardFormatError as error:
+                except vcard_errors.VCardError as error:
                     message = str(error).splitlines(False)[0].split(':')[0]
                     error_msg = '\n\n'.join((
                         'Wrong message for vCard {vcard_file!r}:'.format(vcard_file=vcard_file),
@@ -233,7 +233,7 @@ class TestVCards(unittest.TestCase):
                 with warnings.catch_warnings(record=True):
                     vc_obj = vcard.VCard(vcard_text, filename=vcard_file)
                 self.assertNotEqual(vc_obj, None)
-            except vcard_errors.VCardFormatError as error:
+            except vcard_errors.VCardError as error:
                 error_msg = '\n\n'.join((
                     'Expected valid vCard for {vcard_file!r}, but it failed to validate'.format(
                         vcard_file=vcard_file
@@ -251,7 +251,7 @@ class TestVCards(unittest.TestCase):
 
             with warnings.catch_warnings(record=True):
                 self.assertRaises(
-                    vcard_errors.VCardFormatError,
+                    vcard_errors.VCardError,
                     vcard.VCard,
                     vcard_text)
 

--- a/vcard/vcard_errors.py
+++ b/vcard/vcard_errors.py
@@ -3,50 +3,67 @@
 import sys
 
 # Error literals
-MSG_CONTINUATION_AT_START = 'Continuation line at start of vCard (See RFC \
-2425 section 5.8.1 for line folding details)'
-MSG_DOT_AT_LINE_START = 'Dot at start of line without group name (See RFC \
-2426 section 4 for group syntax)'
+
+# General
 MSG_EMPTY_VCARD = 'vCard is empty'
-MSG_INVALID_DATE = 'Invalid date (See RFC 2425 section 5.8.4 for date syntax)'
-MSG_INVALID_LANGUAGE_VALUE = 'Invalid language (See RFC 1766 section 2 for \
-details)'
-MSG_INVALID_LINE_SEPARATOR = 'Invalid line ending; should be \\r\\n (See RFC \
-2426 section 2.4.2 for details)'
-MSG_INVALID_PARAM_NAME = 'Invalid parameter name (See RFC 2426 section 4 for \
-param-name syntax)'
-MSG_INVALID_PARAM_VALUE = 'Invalid parameter value (See RFC 2426 section 4 \
-for param-value syntax)'
-MSG_INVALID_PROPERTY_NAME = 'Invalid property name (See RFC 2426 section 4 \
-for name syntax)'
-MSG_INVALID_SUBVALUE = 'Invalid subvalue (See RFC 2426 section 3 for details)'
-MSG_INVALID_SUBVALUE_COUNT = 'Invalid subvalue count (See RFC 2426 section 3 \
-for details)'
-MSG_INVALID_TEXT_VALUE = 'Invalid text value (See RFC 2426 section 4 for \
-details)'
-MSG_INVALID_TIME = 'Invalid time (See RFC 2425 section 5.8.4 for time syntax)'
-MSG_INVALID_TIME_ZONE = 'Invalid time zone (See RFC 2426 section 3.4.1 for \
-time-zone syntax)'
-MSG_INVALID_URI = 'Invalid URI (See RFC 1738 section 5 for genericurl syntax)'
-MSG_INVALID_VALUE = 'Invalid value (See RFC 2426 section 3 for details)'
-MSG_INVALID_VALUE_COUNT = 'Invalid value count (See RFC 2426 section 3 for \
-details)'
-MSG_INVALID_X_NAME = 'Invalid X-name (See RFC 2426 section 4 for x-name \
-syntax)'
-MSG_MISMATCH_GROUP = 'Group mismatch (See RFC 2426 section 4 for contentline \
-syntax)'
-MSG_MISMATCH_PARAM = 'Parameter mismatch (See RFC 2426 section 3 for details)'
-MSG_MISSING_GROUP = 'Missing group (See RFC 2426 section 4 for contentline \
-syntax)'
-MSG_MISSING_PARAM = 'Parameter missing (See RFC 2426 section 3 for details)'
-MSG_MISSING_PARAM_VALUE = 'Parameter value missing (See RFC 2426 section 3 \
-for details)'
-MSG_MISSING_PROPERTY = 'Mandatory property missing (See RFC 2426 section 5 \
-for details)'
-MSG_MISSING_VALUE_STRING = 'Missing value string (See RFC 2426 section 4 for \
-contentline syntax)'
-MSG_NON_EMPTY_PARAM = 'Property should not have parameters (See RFC 2426 \
-section 3 for details)'
+
+# Lines
+MSG_CONTINUATION_AT_START = 'Continuation line at start of vCard '\
+    '(See RFC 2425 section 5.8.1 for line folding details)'
+MSG_INVALID_LINE_SEPARATOR = 'Invalid line ending; should be \\r\\n '\
+    '(See RFC 2426 section 2.4.2 for details)'
+MSG_DOT_AT_LINE_START = 'Dot at start of line without group name '\
+    '(See RFC 2426 section 4 for group syntax)'
+MSG_MISSING_GROUP = 'Missing group '\
+    '(See RFC 2426 section 4 for contentline syntax)'
+
+# Item counts & Length
+MSG_NON_EMPTY_PARAM = 'Property should not have parameters '\
+    '(See RFC 2426 section 3 for details)'
+MSG_INVALID_SUBVALUE_COUNT = 'Invalid subvalue count '\
+    '(See RFC 2426 section 3 for details)'
+MSG_INVALID_VALUE_COUNT = 'Invalid value count '\
+    '(See RFC 2426 section 3 for details)'
+MSG_MISSING_PARAM = 'Parameter missing '\
+    '(See RFC 2426 section 3 for details)'
+MSG_MISSING_PARAM_VALUE = 'Parameter value missing '\
+    '(See RFC 2426 section 3 for details)'
+MSG_MISSING_PROPERTY = 'Mandatory property missing '\
+    '(See RFC 2426 section 5 for details)'
+MSG_MISSING_VALUE_STRING = 'Missing value string '\
+    '(See RFC 2426 section 4 for contentline syntax)'
+
+# Names
+MSG_INVALID_PROPERTY_NAME = 'Invalid property name '\
+    '(See RFC 2426 section 4 for name syntax)'
+MSG_INVALID_X_NAME = 'Invalid X-name '\
+    '(See RFC 2426 section 4 for x-name syntax)'
+MSG_INVALID_PARAM_NAME = 'Invalid parameter name '\
+    '(See RFC 2426 section 4 for param-name syntax)'
+MSG_MISMATCH_GROUP = 'Group mismatch '\
+    '(See RFC 2426 section 4 for contentline syntax)'
+
+# Values & Subvalues
+MSG_INVALID_PARAM_VALUE = 'Invalid parameter value '\
+    '(See RFC 2426 section 4 for param-value syntax)'
+MSG_MISMATCH_PARAM = 'Parameter mismatch '\
+    '(See RFC 2426 section 3 for details)'
+MSG_INVALID_DATE = 'Invalid date '\
+    '(See RFC 2425 section 5.8.4 for date syntax)'
+MSG_INVALID_LANGUAGE_VALUE = 'Invalid language '\
+    '(See RFC 1766 section 2 for details)'
+MSG_INVALID_SUBVALUE = 'Invalid subvalue '\
+    '(See RFC 2426 section 3 for details)'
+MSG_INVALID_TEXT_VALUE = 'Invalid text value '\
+    '(See RFC 2426 section 4 for details)'
+MSG_INVALID_TIME = 'Invalid time '\
+    '(See RFC 2425 section 5.8.4 for time syntax)'
+MSG_INVALID_TIME_ZONE = 'Invalid time zone '\
+    '(See RFC 2426 section 3.4.1 for time-zone syntax)'
+MSG_INVALID_URI = 'Invalid URI '\
+    '(See RFC 1738 section 5 for genericurl syntax)'
+MSG_INVALID_VALUE = 'Invalid value '\
+    '(See RFC 2426 section 3 for details)'
 
 # Warning literals
 WARN_DEFAULT_TYPE_VALUE = 'Using default TYPE value; can be removed'
@@ -81,8 +98,8 @@ def show_warning(
     file.write('{0}\n'.format(message))
 
 
-class VCardFormatError(Exception):
-    """Thrown if the text given is not a valid according to RFC 2426."""
+class VCardError(Exception):
+    """Raised if the text given is not a valid according to RFC 2426."""
     def __init__(self, message, context):
         """
         vCard format error.
@@ -91,16 +108,16 @@ class VCardFormatError(Exception):
         @param context: Dictionary with context information
 
         Examples:
-        >>> raise VCardFormatError('test', {})
+        >>> raise VCardError('test', {})
         Traceback (most recent call last):
-        VCardFormatError: test
-        >>> raise VCardFormatError(
+        VCardError: test
+        >>> raise VCardError(
         ... 'with path',
         ... {'File': '/home/user/test.vcf'})
         Traceback (most recent call last):
-        VCardFormatError: with path
+        VCardError: with path
         File: /home/user/test.vcf
-        >>> raise VCardFormatError('Error with lots of context', {
+        >>> raise VCardError('Error with lots of context', {
         ... 'File': '/home/user/test.vcf',
         ... 'File line': 120,
         ... 'vCard line': 5,
@@ -108,7 +125,7 @@ class VCardFormatError(Exception):
         ... 'Property line': 2,
         ... 'String': 'too;few;values;êéè'})
         Traceback (most recent call last):
-        VCardFormatError: Error with lots of context
+        VCardError: Error with lots of context
         File: /home/user/test.vcf
         File line: 120
         vCard line: 5
@@ -116,20 +133,20 @@ class VCardFormatError(Exception):
         Property line: 2
         String: too;few;values;êéè
         >>> try:
-        ...     raise VCardFormatError('test', {'Property': 'ADR'})
-        ... except VCardFormatError as error:
+        ...     raise VCardError('test', {'Property': 'ADR'})
+        ... except VCardError as error:
         ...     error.context['File'] = '/home/user/test.vcf'
-        ...     raise VCardFormatError(error.message, error.context)
+        ...     raise VCardError(error.message, error.context)
         Traceback (most recent call last):
-        VCardFormatError: test
+        VCardError: test
         File: /home/user/test.vcf
         Property: ADR
         >>> import vcard_defs
-        >>> raise VCardFormatError(
+        >>> raise VCardError(
         ... 'Cöntexte randomisę',
         ... {'foo': vcard_defs.QSAFE_CHARS[-1]*2})
         Traceback (most recent call last):
-        VCardFormatError: Cöntexte randomisę
+        VCardError: Cöntexte randomisę
         foo: ÿÿ
         """
         Exception.__init__(self)
@@ -167,6 +184,26 @@ class VCardFormatError(Exception):
             )
 
         return message
+
+
+class VCardLineError(VCardError):
+    """Raised for line-related errors."""
+    pass
+
+
+class VCardNameError(VCardError):
+    """Raised for name-related errors."""
+    pass
+
+
+class VCardValueError(VCardError):
+    """Raised for value-related errors."""
+    pass
+
+
+class VCardItemCountError(VCardError):
+    """Raised when a required number of something is not present."""
+    pass
 
 
 class UsageError(Exception):


### PR DESCRIPTION
- `VCardFormatError` renamed to `VCardError`
- Error Subclasses for Names, Values, and ItemCount

---

Dunno what you’ll think of this one, @l0b0, but I thought some error types which describe more specific types of VCard errors would be helpful for the end-user.  

The classes  `VCardNameError` and `VCardValueError` are a nice parallel to the standard library exceptions `NameError` and `ValueError` (although they only inherit from `VCardError`).  

The class `VCardItemCountError` is vaguely like the standard library `IndexError`, in that both are raised when an expected number of something is out of bounds.

Finally, there’s the `VCardLineError` class, whose name makes it pretty obvious what went wrong. :)
