### PR TITLE
split.sh: append .vcf suffix, only, to end of file

### DIFF
--- a/split.sh
+++ b/split.sh
@@ -37,5 +37,5 @@ set -o errexit -o noclobber -o nounset -o pipefail
 
 for path
 do
-    csplit --elide-empty-files --digits=8 --prefix "$(basename -- "$path")" "$path" $'/^BEGIN:VCARD\r$/' '{*}' >/dev/null
+    csplit --elide-empty-files --prefix "$(basename -- "$path" .vcf)" --suffix-format "-%08d.vcf" "$path" $'/^BEGIN:VCARD\r$/' '{*}' >/dev/null
 done


### PR DESCRIPTION
This commit makes the output files of split.sh end in .vcf and strips any internal ".vcf": 

```
$ split.sh bigfile.vcf
$ ls
bigfile.vcf
bigfile-00000000.vcf
bigfile-00000001.vcf
bigfile-00000002.vcf
...
```

Currently in l0b0/vcard/master, split.sh results in:

```
$ split.sh bigfile.vcf
$ ls
bigfile.vcf
bigfile.vcf00000000
bigfile.vcf00000001
bigfile.vcf00000002
...
```
